### PR TITLE
Workaround for making C-x 3 work

### DIFF
--- a/perfect-margin.el
+++ b/perfect-margin.el
@@ -290,6 +290,11 @@ WIN will be any visible window, including the minimap window."
               minimap-hide-fringes)
     (set-window-fringes (minimap-get-window) 0 0)))
 
+(defadvice split-window (before perfect-margin--disable-margins nil)
+  (dolist (win (window-list))
+    (set-window-margins win 0 0)
+    (set-window-fringes win 0 0)))
+
 ;;----------------------------------------------------------------------------
 ;; MINOR mode definition
 ;;----------------------------------------------------------------------------
@@ -308,6 +313,7 @@ WIN will be any visible window, including the minimap window."
             (setq linum-format 'perfect-margin--linum-format)))
         (when (perfect-margin-with-minimap-p)
           (ad-activate 'minimap-update))
+        (ad-activate 'split-window)
         (add-hook 'window-configuration-change-hook 'perfect-margin-margin-windows)
         (add-hook 'window-size-change-functions 'perfect-margin-margin-frame)
         (perfect-margin-margin-windows))
@@ -319,6 +325,7 @@ WIN will be any visible window, including the minimap window."
       (linum-update-current))
     (when (perfect-margin-with-minimap-p)
       (ad-deactivate 'minimap-update))
+    (ad-deactivate 'split-window)
     (remove-hook 'window-configuration-change-hook 'perfect-margin-margin-windows)
     (remove-hook 'window-size-change-functions 'perfect-margin-margin-frame)
     (dolist (window (window-list))


### PR DESCRIPTION
Hi,

`split-window-right` (`C-x 3`) doesn't work when the window is centered. I fixed it by removing the margins temporarily before `split-window` is called, like `olivetti-mode` does.